### PR TITLE
remove dependency onto goamz

### DIFF
--- a/private/signer/s3/s3.go
+++ b/private/signer/s3/s3.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	goaws "github.com/mitchellh/goamz/aws"
 	"github.com/tily/sdk-go/aws/credentials"
 	"github.com/tily/sdk-go/aws/request"
 	"time"
@@ -15,6 +14,12 @@ var SignRequestHandler = request.NamedHandler{
 	Name: "s3.SignRequestHandler", Fn: SignSDKRequest,
 }
 
+type Auth struct {
+	AccessKey string
+	SecretKey string
+	Token     string
+}
+
 func SignSDKRequest(req *request.Request) {
 	if req.Config.Credentials == credentials.AnonymousCredentials {
 		return
@@ -25,7 +30,7 @@ func SignSDKRequest(req *request.Request) {
 		return
 	}
 
-	auth := goaws.Auth{credValue.AccessKeyID, credValue.SecretAccessKey, credValue.SessionToken}
+	auth := Auth{credValue.AccessKeyID, credValue.SecretAccessKey, credValue.SessionToken}
 	method := req.HTTPRequest.Method
 	canonicalPath := req.HTTPRequest.URL.Path
 	params := req.HTTPRequest.URL.Query()

--- a/private/signer/s3/sign.go
+++ b/private/signer/s3/sign.go
@@ -7,8 +7,6 @@ import (
 	"log"
 	"sort"
 	"strings"
-
-	"github.com/mitchellh/goamz/aws"
 )
 
 var b64 = base64.StdEncoding
@@ -39,7 +37,7 @@ var s3ParamsToSign = map[string]bool{
 	"response-content-encoding":    true,
 }
 
-func sign(auth aws.Auth, method, canonicalPath string, params, headers map[string][]string) {
+func sign(auth Auth, method, canonicalPath string, params, headers map[string][]string) {
 	var md5, ctype, date, xamz string
 	var xamzDate bool
 	var sarray []string


### PR DESCRIPTION
## Summary

* remove dependency onto goamz

## Tests

* the program below executes normally:

```go
package main

import (
        "fmt"
        "github.com/tily/sdk-go/aws"
        "github.com/tily/sdk-go/aws/session"
        "github.com/tily/sdk-go/service/storage"
)

func main() {
        jpEast1, err := session.NewSession(&aws.Config{
                Region: aws.String("jp-east-1"),
        })

        storageClient := storage.New(jpEast1)
        storageRes, err := storageClient.ListBuckets(nil)
        if err != nil {
                panic(err)
        }
        fmt.Printf("%#v\n", storageRes)
}
```